### PR TITLE
fix : 앱 실행시 새로운 플레이 데이터 유무와 관계 없이 항상 데이터를 리프래쉬하는 이슈 수정

### DIFF
--- a/lib/presentation/play_data/view_models/my_data_view_model.dart
+++ b/lib/presentation/play_data/view_models/my_data_view_model.dart
@@ -27,15 +27,6 @@ class MyDataViewModel extends GetxController {
     if (clearDataList.isEmpty) {
       // Get Clear Data from RemoteDataSource
       await getClearDataFromRemote();
-    } else {
-      // Check if there is new clear data
-      // when the user's total clear count is different from the local data
-      int totalClearCount = clearDataList.where((element) => element.level >= 10).length;
-
-      if (totalClearCount != MyDataService.to.myData.totalClear) {
-        Fluttertoast.showToast(msg: "새로운 클리어 정보가 있습니다.\n클리어 정보를 갱신합니다.");
-        await getClearDataFromRemote();
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
앱 실행시 플레이 여부와 관계없이 매번 데이터 리프래시 현상 발생
플레이 카운트 체크하여 데이터 리프래쉬하는 로직에서 문제 발견
해당 로직 삭제

<img width="514" alt="스크린샷 2024-06-13 오후 9 05 14" src="https://github.com/SerenityS/MyPIU/assets/16794863/62642f1c-4ba2-4592-8d89-97d5f9e99785">
<img width="468" alt="스크린샷 2024-06-13 오후 9 06 01" src="https://github.com/SerenityS/MyPIU/assets/16794863/1e4c2403-854a-4de0-a86c-2f370f5e0154">


## Related Issue
https://github.com/SerenityS/MyPIU/issues/27